### PR TITLE
fix: Se nenhum argumento é passado a ferramenta exibe a ajuda

### DIFF
--- a/bin/g-flow.sh
+++ b/bin/g-flow.sh
@@ -51,6 +51,13 @@ COMMANDS (unless otherwise overriden by a .g-flowrc file)
         Creates a hotfix branch
 '
 
+# If no arguments were passed, shows the USAGE and exits
+
+if [ "$#" -eq 0 ]; then
+    echo "$USAGE"
+    exit 0
+fi
+
 # If there's a .g-flowrc file present, override the configuration keys present in this file
 
 if [ -e ".g-flowrc" ]; then


### PR DESCRIPTION
Sem exibir erros.